### PR TITLE
Feature de favoritos

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+
+    alias(libs.plugins.safe.args)
 }
 
 android {
@@ -33,6 +35,9 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures{
+        viewBinding=true
+    }
 }
 
 dependencies {
@@ -42,6 +47,10 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+
+    implementation(libs.androidx.navigation.fragment.ktx)
+    implementation(libs.androidx.navigation.ui.ktx)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-
+    alias(libs.plugins.ksp)
     alias(libs.plugins.safe.args)
 }
 
@@ -48,10 +48,22 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
 
+    implementation(libs.viewmodelscope)
+
+    implementation (libs.gson)
+
+    implementation(project.dependencies.platform(libs.koin.bom))
+    implementation(libs.koin.android)
+    implementation(libs.koin.annotations)
+    ksp(libs.koin.ksp)
+
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+}
+ksp {
+    arg("koin.annotation.processor", "true")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <application
         android:allowBackup="true"
+        android:name=".app.PmdmApplication"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/app/AppModule.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/app/AppModule.kt
@@ -1,10 +1,22 @@
 package com.alfsuace.expmdmfebrero.app
 
+import com.alfsuace.expmdmfebrero.data.local.AlbumMock
+import com.google.gson.Gson
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
 
 @Module
 @ComponentScan("com.alfsuace.expmdmfebrero")
 class AppModule {
 
+    @Single
+    fun provideGson():Gson{
+        return Gson()
+    }
+
+    @Single
+    fun provideMock():AlbumMock{
+        return AlbumMock()
+    }
 }

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/app/AppModule.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/app/AppModule.kt
@@ -1,0 +1,10 @@
+package com.alfsuace.expmdmfebrero.app
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+
+@Module
+@ComponentScan("com.alfsuace.expmdmfebrero")
+class AppModule {
+
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/app/PmdmApplication.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/app/PmdmApplication.kt
@@ -1,0 +1,20 @@
+package com.alfsuace.expmdmfebrero.app
+
+import android.app.Application
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+import org.koin.ksp.generated.module
+
+class PmdmApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidContext(this@PmdmApplication)
+            modules(
+                AppModule().module,
+
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/data/AlbumDataRepository.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/data/AlbumDataRepository.kt
@@ -3,7 +3,9 @@ package com.alfsuace.expmdmfebrero.data
 import com.alfsuace.expmdmfebrero.data.local.AlbumLocalDataRepository
 import com.alfsuace.expmdmfebrero.domain.Album
 import com.alfsuace.expmdmfebrero.domain.AlbumRepository
+import org.koin.core.annotation.Single
 
+@Single
 class AlbumDataRepository(private val local: AlbumLocalDataRepository):AlbumRepository {
     override fun getAlbums(): List<Album> {
         return local.getAllAlbums()

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/data/AlbumDataRepository.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/data/AlbumDataRepository.kt
@@ -1,0 +1,16 @@
+package com.alfsuace.expmdmfebrero.data
+
+import com.alfsuace.expmdmfebrero.data.local.AlbumLocalDataRepository
+import com.alfsuace.expmdmfebrero.domain.Album
+import com.alfsuace.expmdmfebrero.domain.AlbumRepository
+
+class AlbumDataRepository(private val local: AlbumLocalDataRepository):AlbumRepository {
+    override fun getAlbums(): List<Album> {
+        return local.getAllAlbums()
+    }
+
+    override fun getAlbumById(id: String): Album? {
+        return local.getAlbumById(id)
+    }
+
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumLocalDataRepository.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumLocalDataRepository.kt
@@ -3,27 +3,18 @@ package com.alfsuace.expmdmfebrero.data.local
 import android.content.Context
 import com.google.gson.Gson
 import com.alfsuace.expmdmfebrero.domain.Album
+import org.koin.core.annotation.Single
 
+@Single
 class AlbumLocalDataRepository(private val context: Context) {
     private val gson = Gson()
     private val mock = AlbumMock()
     private val prefs = context.getSharedPreferences("album_prefs", Context.MODE_PRIVATE)
 
-
-    fun saveAlbum(album: Album) {
-        val albumJson = gson.toJson(album)
-        prefs.edit().putString(album.id, albumJson).apply()
-    }
-
     fun getAlbumById(id: String): Album? {
         val albumJson = prefs.getString(id, null)
         return gson.fromJson(albumJson, Album::class.java)
     }
-
-    fun deleteAlbum(id: String) {
-        prefs.edit().remove(id).apply()
-    }
-
 
     fun saveAlbums(albums: List<Album>) {
         val editor = prefs.edit()

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumLocalDataRepository.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumLocalDataRepository.kt
@@ -6,9 +6,7 @@ import com.alfsuace.expmdmfebrero.domain.Album
 import org.koin.core.annotation.Single
 
 @Single
-class AlbumLocalDataRepository(private val context: Context) {
-    private val gson = Gson()
-    private val mock = AlbumMock()
+class AlbumLocalDataRepository(private val context: Context, private val gson: Gson, private val mock: AlbumMock) {
     private val prefs = context.getSharedPreferences("album_prefs", Context.MODE_PRIVATE)
 
     fun getAlbumById(id: String): Album? {

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumLocalDataRepository.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumLocalDataRepository.kt
@@ -1,0 +1,55 @@
+package com.alfsuace.expmdmfebrero.data.local
+
+import android.content.Context
+import com.google.gson.Gson
+import com.alfsuace.expmdmfebrero.domain.Album
+
+class AlbumLocalDataRepository(private val context: Context) {
+    private val gson = Gson()
+    private val mock = AlbumMock()
+    private val prefs = context.getSharedPreferences("album_prefs", Context.MODE_PRIVATE)
+
+
+    fun saveAlbum(album: Album) {
+        val albumJson = gson.toJson(album)
+        prefs.edit().putString(album.id, albumJson).apply()
+    }
+
+    fun getAlbumById(id: String): Album? {
+        val albumJson = prefs.getString(id, null)
+        return gson.fromJson(albumJson, Album::class.java)
+    }
+
+    fun deleteAlbum(id: String) {
+        prefs.edit().remove(id).apply()
+    }
+
+
+    fun saveAlbums(albums: List<Album>) {
+        val editor = prefs.edit()
+        albums.forEach { album ->
+            val albumJson = gson.toJson(album)
+            editor.putString(album.id, albumJson)
+        }
+        editor.apply()
+    }
+
+    fun getAllAlbums(): List<Album> {
+        val albums = mutableListOf<Album>()
+        prefs.all.forEach { (_, value) ->
+            val albumJson = value as? String ?: return@forEach
+            try {
+                val album = gson.fromJson(albumJson, Album::class.java)
+                albums.add(album)
+            } catch (e: Exception) {
+                // Manejar error si es necesario.
+            }
+        }
+        return if (albums.isEmpty()){
+            saveAlbums(mock.getAlbums())
+            mock.getAlbums()
+        }else{
+            albums
+        }
+    }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumMock.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumMock.kt
@@ -1,0 +1,111 @@
+package com.alfsuace.expmdmfebrero.data.local
+
+import com.alfsuace.expmdmfebrero.domain.Album
+import com.alfsuace.expmdmfebrero.domain.Mushroom
+
+class AlbumMock {
+    val mushrooms = listOf(
+        Mushroom("1", "Amanita Muscaria", "https://example.com/amanita.jpg"),
+        Mushroom("2", "Boletus Edulis", "https://example.com/boletus.jpg"),
+        Mushroom("3", "Cantharellus Cibarius", "https://example.com/cantharellus.jpg"),
+        Mushroom("4", "Coprinus Comatus", "https://example.com/coprinus.jpg"),
+        Mushroom("5", "Lactarius Deliciosus", "https://example.com/lactarius.jpg")
+    )
+
+    private val albums = listOf(
+        Album(
+            "101",
+            "Bosque Encantado",
+            "2024-01-15",
+            "Explorando setas en el bosque",
+            "https://example.com/album1.jpg",
+            false,
+            listOf(mushrooms[0], mushrooms[1])
+        ),
+        Album(
+            "102",
+            "Amanecer Micológico",
+            "2024-02-20",
+            "Recolección de hongos al amanecer",
+            "https://example.com/album2.jpg",
+            false,
+            listOf(mushrooms[2], mushrooms[3])
+        ),
+        Album(
+            "103",
+            "Senderos Fungícos",
+            "2024-03-10",
+            "Un recorrido lleno de vida y setas",
+            "https://example.com/album3.jpg",
+            false,
+            listOf(mushrooms[4], mushrooms[0])
+        ),
+        Album(
+            "104",
+            "Misterios del Bosque",
+            "2024-04-05",
+            "Setas poco comunes en la naturaleza",
+            "https://example.com/album4.jpg",
+            false,
+            listOf(mushrooms[1], mushrooms[3])
+        ),
+        Album(
+            "105",
+            "Tesoros del Otoño",
+            "2024-05-25",
+            "Las mejores setas de la temporada",
+            "https://example.com/album5.jpg",
+            false,
+            listOf(mushrooms[2], mushrooms[4])
+        ),
+        Album(
+            "106",
+            "Cosecha Micológica",
+            "2024-06-12",
+            "Descubriendo nuevos sabores",
+            "https://example.com/album6.jpg",
+            false,
+            listOf(mushrooms[3], mushrooms[0])
+        ),
+        Album(
+            "107",
+            "Exploradores de Setas",
+            "2024-07-18",
+            "Un viaje educativo en la micología",
+            "https://example.com/album7.jpg",
+            false,
+            listOf(mushrooms[1], mushrooms[4])
+        ),
+        Album(
+            "108",
+            "Bajo la Lluvia",
+            "2024-08-30",
+            "Setas encontradas después de la lluvia",
+            "https://example.com/album8.jpg",
+            false,
+            listOf(mushrooms[0], mushrooms[2])
+        ),
+        Album(
+            "109",
+            "Colores y Sabores",
+            "2024-09-22",
+            "Una colección de setas vibrantes",
+            "https://example.com/album9.jpg",
+            false,
+            listOf(mushrooms[3], mushrooms[4])
+        ),
+        Album(
+            "110",
+            "El Reino Fungi",
+            "2024-10-05",
+            "Un tributo a la diversidad de hongos",
+            "https://example.com/album10.jpg",
+            false,
+            listOf(mushrooms[1], mushrooms[2])
+        )
+    )
+
+    fun getAlbums(): List<Album> = albums
+
+    fun getAlbumById(id: String): Album? = albums.find { it.id == id }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumMock.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/data/local/AlbumMock.kt
@@ -2,7 +2,9 @@ package com.alfsuace.expmdmfebrero.data.local
 
 import com.alfsuace.expmdmfebrero.domain.Album
 import com.alfsuace.expmdmfebrero.domain.Mushroom
+import org.koin.core.annotation.Single
 
+@Single
 class AlbumMock {
     val mushrooms = listOf(
         Mushroom("1", "Amanita Muscaria", "https://example.com/amanita.jpg"),

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/domain/AlbumRepository.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/domain/AlbumRepository.kt
@@ -1,0 +1,8 @@
+package com.alfsuace.expmdmfebrero.domain
+
+interface AlbumRepository {
+
+    fun getAlbums():List<Album>
+    fun getAlbumById(id: String): Album?
+
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumByIdUseCase.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumByIdUseCase.kt
@@ -1,0 +1,9 @@
+package com.alfsuace.expmdmfebrero.domain
+
+class GetAlbumByIdUseCase(private val albumRepository: AlbumRepository) {
+
+    operator fun invoke(id: String): Album? {
+        return albumRepository.getAlbumById(id)
+    }
+
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumByIdUseCase.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumByIdUseCase.kt
@@ -1,7 +1,9 @@
 package com.alfsuace.expmdmfebrero.domain
 
-class GetAlbumByIdUseCase(private val albumRepository: AlbumRepository) {
+import org.koin.core.annotation.Single
 
+@Single
+class GetAlbumByIdUseCase(private val albumRepository: AlbumRepository) {
     operator fun invoke(id: String): Album? {
         return albumRepository.getAlbumById(id)
     }

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumsUseCase.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumsUseCase.kt
@@ -1,7 +1,9 @@
 package com.alfsuace.expmdmfebrero.domain
 
-class GetAlbumsUseCase(private val albumRepository: AlbumRepository) {
+import org.koin.core.annotation.Single
 
+@Single
+class GetAlbumsUseCase(private val albumRepository: AlbumRepository) {
     operator fun invoke():List<Album>{
         return albumRepository.getAlbums()
     }

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumsUseCase.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/domain/GetAlbumsUseCase.kt
@@ -1,0 +1,8 @@
+package com.alfsuace.expmdmfebrero.domain
+
+class GetAlbumsUseCase(private val albumRepository: AlbumRepository) {
+
+    operator fun invoke():List<Album>{
+        return albumRepository.getAlbums()
+    }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/domain/Models.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/domain/Models.kt
@@ -1,0 +1,17 @@
+package com.alfsuace.expmdmfebrero.domain
+
+data class Album(
+    val id: String,
+    val name: String,
+    val dateCreated: String,
+    val description: String,
+    val image: String,
+    val favorite: Boolean,
+    val mushrooms: List<Mushroom>
+)
+
+data class Mushroom(
+    val id: String,
+    val name: String,
+    val image: String
+)

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
@@ -1,0 +1,89 @@
+package com.alfsuace.expmdmfebrero.presentation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.alfsuace.expmdmfebrero.R
+import com.alfsuace.expmdmfebrero.data.AlbumDataRepository
+import com.alfsuace.expmdmfebrero.data.local.AlbumLocalDataRepository
+import com.alfsuace.expmdmfebrero.data.local.AlbumMock
+import com.alfsuace.expmdmfebrero.databinding.FragmentAlbumListBinding
+import com.alfsuace.expmdmfebrero.domain.GetAlbumsUseCase
+import com.alfsuace.expmdmfebrero.presentation.adapter.AlbumAdapter
+
+class AlbumListFragment : Fragment(R.layout.fragment_album_list) {
+
+    private var _binding: FragmentAlbumListBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: AlbumListViewModel by lazy {
+        AlbumListViewModel(
+            GetAlbumsUseCase(
+                AlbumDataRepository(
+                    AlbumLocalDataRepository(requireContext())
+                )
+            )
+        )
+    }
+
+    private lateinit var adapter: AlbumAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentAlbumListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        adapter = AlbumAdapter(
+            onClick = { navigateToDetail(it.id) },
+            onFavoriteClick = { viewModel.clickedFavorite(it) }
+        )
+        setUpRecyclerView()
+        setUpObserver()
+        viewModel.loadAlbums()
+        binding.toolbar.toolbar.setOnMenuItemClickListener { item ->
+            when (item.itemId) {
+                R.id.action_bookmark -> {
+                    viewModel.toggleShowFavorites()
+                    true
+                }
+                else -> false
+            }
+        }
+    }
+
+    private fun navigateToDetail(id: String) {
+        findNavController().navigate(AlbumListFragmentDirections.actionAlbumListFragmentToStickerListFragment(id))
+    }
+
+    private fun setUpRecyclerView() {
+        binding.albumList.layoutManager = LinearLayoutManager(
+            requireContext(),
+            LinearLayoutManager.VERTICAL,
+            false
+        )
+        binding.albumList.adapter = adapter
+    }
+
+    private fun setUpObserver(){
+        val observer = Observer<AlbumListViewModel.UiState>{
+            adapter.submitList(it.albums)
+        }
+        viewModel.uiState.observe(viewLifecycleOwner, observer)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
@@ -10,27 +10,16 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.alfsuace.expmdmfebrero.R
-import com.alfsuace.expmdmfebrero.data.AlbumDataRepository
-import com.alfsuace.expmdmfebrero.data.local.AlbumLocalDataRepository
-import com.alfsuace.expmdmfebrero.data.local.AlbumMock
 import com.alfsuace.expmdmfebrero.databinding.FragmentAlbumListBinding
-import com.alfsuace.expmdmfebrero.domain.GetAlbumsUseCase
 import com.alfsuace.expmdmfebrero.presentation.adapter.AlbumAdapter
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class AlbumListFragment : Fragment(R.layout.fragment_album_list) {
 
     private var _binding: FragmentAlbumListBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: AlbumListViewModel by lazy {
-        AlbumListViewModel(
-            GetAlbumsUseCase(
-                AlbumDataRepository(
-                    AlbumLocalDataRepository(requireContext())
-                )
-            )
-        )
-    }
+    private val viewModel: AlbumListViewModel by viewModel()
 
     private lateinit var adapter: AlbumAdapter
 

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
@@ -51,7 +51,7 @@ class AlbumListFragment : Fragment(R.layout.fragment_album_list) {
         setUpRecyclerView()
         setUpObserver()
         viewModel.loadAlbums()
-        binding.toolbar.toolbar.setOnMenuItemClickListener { item ->
+        binding.toolbarAlbum.toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.action_bookmark -> {
                     viewModel.toggleShowFavorites()

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListFragment.kt
@@ -1,6 +1,7 @@
 package com.alfsuace.expmdmfebrero.presentation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -77,6 +78,12 @@ class AlbumListFragment : Fragment(R.layout.fragment_album_list) {
 
     private fun setUpObserver(){
         val observer = Observer<AlbumListViewModel.UiState>{
+            if (it.loading) {
+                Log.d("@dev", "Cargando datos...")
+            }
+            if (it.error) {
+                Log.d("@dev", "Ocurrió un error al cargar los datos")
+            }
             adapter.submitList(it.albums)
         }
         viewModel.uiState.observe(viewLifecycleOwner, observer)

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListViewModel.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListViewModel.kt
@@ -8,7 +8,9 @@ import com.alfsuace.expmdmfebrero.domain.Album
 import com.alfsuace.expmdmfebrero.domain.GetAlbumsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.koin.android.annotation.KoinViewModel
 
+@KoinViewModel
 class AlbumListViewModel(private val getAlbumsUseCase: GetAlbumsUseCase) : ViewModel() {
 
     private val _uiState = MutableLiveData<UiState>()

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListViewModel.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/AlbumListViewModel.kt
@@ -1,0 +1,60 @@
+package com.alfsuace.expmdmfebrero.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.alfsuace.expmdmfebrero.domain.Album
+import com.alfsuace.expmdmfebrero.domain.GetAlbumsUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class AlbumListViewModel(private val getAlbumsUseCase: GetAlbumsUseCase) : ViewModel() {
+
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> get() = _uiState
+
+    private var allAlbums: List<Album> = emptyList()
+    private var showOnlyFavorites = false
+
+    fun loadAlbums() {
+        _uiState.value = UiState(loading = true)
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                allAlbums = getAlbumsUseCase()
+                _uiState.postValue(UiState(albums = allAlbums))
+            } catch (e: Exception) {
+                _uiState.postValue(UiState(error = true))
+            }
+        }
+    }
+
+    fun clickedFavorite(album: Album) {
+        viewModelScope.launch {
+            allAlbums = allAlbums.map {
+                if (it.id == album.id) it.copy(favorite = !it.favorite) else it
+            }
+            updateAlbumList()
+        }
+    }
+
+    fun toggleShowFavorites() {
+        showOnlyFavorites = !showOnlyFavorites
+        updateAlbumList()
+    }
+
+    private fun updateAlbumList() {
+        val filteredAlbums = if (showOnlyFavorites) {
+            allAlbums.filter { it.favorite }
+        } else {
+            allAlbums
+        }
+        _uiState.postValue(UiState(albums = filteredAlbums))
+    }
+
+    data class UiState(
+        val loading: Boolean = false,
+        val error: Boolean = false,
+        val albums: List<Album> = emptyList()
+    )
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
@@ -1,0 +1,85 @@
+package com.alfsuace.expmdmfebrero.presentation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.alfsuace.expmdmfebrero.R
+import com.alfsuace.expmdmfebrero.data.AlbumDataRepository
+import com.alfsuace.expmdmfebrero.data.local.AlbumLocalDataRepository
+import com.alfsuace.expmdmfebrero.databinding.FragmentDetailAlbumBinding
+import com.alfsuace.expmdmfebrero.domain.GetAlbumByIdUseCase
+import com.alfsuace.expmdmfebrero.presentation.adaptersticker.MushroomAdapter
+
+class StickerListFragment():Fragment() {
+    private var _binding: FragmentDetailAlbumBinding? = null
+    private val binding get() = _binding!!
+
+    private val args: StickerListFragmentArgs by navArgs()
+
+    private val viewModel: StickerListViewModel by lazy {
+        StickerListViewModel(
+            GetAlbumByIdUseCase(
+                AlbumDataRepository(
+                    AlbumLocalDataRepository(requireContext())
+                )
+            )
+        )
+    }
+
+    private lateinit var adapter: MushroomAdapter
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentDetailAlbumBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        adapter = MushroomAdapter()
+        setUpToolBar()
+        setUpRecyclerView()
+        setUpObserver()
+        viewModel.loadAlbum(args.id.toString())
+    }
+
+    private fun setUpToolBar() {
+
+        binding.toolbar.toolbar.apply {
+            setNavigationOnClickListener {
+                findNavController().navigateUp()
+            }
+        }
+    }
+
+    private fun setUpRecyclerView() {
+        binding.stickerList.layoutManager = LinearLayoutManager(
+            requireContext(),
+            LinearLayoutManager.VERTICAL,
+            false
+        )
+        binding.stickerList.adapter = adapter
+    }
+
+    private fun setUpObserver(){
+        val observer = Observer<StickerListViewModel.UiState>{
+            adapter.submitList(it.album?.mushrooms)
+        }
+        viewModel.uiState.observe(viewLifecycleOwner, observer)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
@@ -54,8 +54,7 @@ class StickerListFragment():Fragment() {
     }
 
     private fun setUpToolBar() {
-
-        binding.toolbar.toolbar.apply {
+        binding.toolbarDetail.toolbar.apply {
             setNavigationOnClickListener {
                 findNavController().navigateUp()
             }

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
@@ -1,6 +1,7 @@
 package com.alfsuace.expmdmfebrero.presentation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -71,7 +72,13 @@ class StickerListFragment():Fragment() {
     }
 
     private fun setUpObserver(){
-        val observer = Observer<StickerListViewModel.UiState>{
+        val observer = Observer<StickerListViewModel.UiState> {
+            if (it.loading) {
+                Log.d("@dev", "Cargando datos...")
+            }
+            if (it.error) {
+                Log.d("@dev", "Ocurrió un error al cargar los datos")
+            }
             adapter.submitList(it.album?.mushrooms)
         }
         viewModel.uiState.observe(viewLifecycleOwner, observer)

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListFragment.kt
@@ -10,12 +10,9 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.alfsuace.expmdmfebrero.R
-import com.alfsuace.expmdmfebrero.data.AlbumDataRepository
-import com.alfsuace.expmdmfebrero.data.local.AlbumLocalDataRepository
 import com.alfsuace.expmdmfebrero.databinding.FragmentDetailAlbumBinding
-import com.alfsuace.expmdmfebrero.domain.GetAlbumByIdUseCase
 import com.alfsuace.expmdmfebrero.presentation.adaptersticker.MushroomAdapter
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class StickerListFragment():Fragment() {
     private var _binding: FragmentDetailAlbumBinding? = null
@@ -23,15 +20,7 @@ class StickerListFragment():Fragment() {
 
     private val args: StickerListFragmentArgs by navArgs()
 
-    private val viewModel: StickerListViewModel by lazy {
-        StickerListViewModel(
-            GetAlbumByIdUseCase(
-                AlbumDataRepository(
-                    AlbumLocalDataRepository(requireContext())
-                )
-            )
-        )
-    }
+    private val viewModel: StickerListViewModel by viewModel()
 
     private lateinit var adapter: MushroomAdapter
 

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListViewModel.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.alfsuace.expmdmfebrero.domain.Album
 import com.alfsuace.expmdmfebrero.domain.GetAlbumByIdUseCase
+import org.koin.android.annotation.KoinViewModel
 
+@KoinViewModel
 class StickerListViewModel(
     private val getAlbumByIdUseCase: GetAlbumByIdUseCase
 ): ViewModel() {

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListViewModel.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/StickerListViewModel.kt
@@ -1,0 +1,31 @@
+package com.alfsuace.expmdmfebrero.presentation
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.alfsuace.expmdmfebrero.domain.Album
+import com.alfsuace.expmdmfebrero.domain.GetAlbumByIdUseCase
+
+class StickerListViewModel(
+    private val getAlbumByIdUseCase: GetAlbumByIdUseCase
+): ViewModel() {
+
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> get() = _uiState
+
+    fun loadAlbum(id: String){
+        _uiState.value = UiState(loading = true)
+        try {
+            val album = getAlbumByIdUseCase(id)
+            _uiState.postValue(UiState(album = album))
+        } catch (e: Exception) {
+            _uiState.postValue(UiState(error = true))
+        }
+    }
+
+    data class UiState(
+        val loading: Boolean= false,
+        val error: Boolean= false,
+        val album: Album? = null
+    )
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumAdapter.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumAdapter.kt
@@ -1,0 +1,24 @@
+package com.alfsuace.expmdmfebrero.presentation.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import com.alfsuace.expmdmfebrero.R
+import com.alfsuace.expmdmfebrero.domain.Album
+
+class AlbumAdapter(
+    private val onClick: (Album) -> Unit,
+    private val onFavoriteClick: (Album) -> Unit
+) : ListAdapter<Album, AlbumViewHolder>(AlbumDiffUtil()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AlbumViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.view_album_item, parent, false)
+        return AlbumViewHolder(view, onClick, onFavoriteClick)
+    }
+
+    override fun onBindViewHolder(holder: AlbumViewHolder, position: Int) {
+        val album = getItem(position)
+        holder.bind(album)
+    }
+}
+

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumDiffUtil.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumDiffUtil.kt
@@ -2,7 +2,9 @@ package com.alfsuace.expmdmfebrero.presentation.adapter
 
 import androidx.recyclerview.widget.DiffUtil
 import com.alfsuace.expmdmfebrero.domain.Album
+import org.koin.core.annotation.Single
 
+@Single
 class AlbumDiffUtil():DiffUtil.ItemCallback<Album>() {
     override fun areItemsTheSame(oldItem: Album, newItem: Album): Boolean {
         return oldItem.id==newItem.id

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumDiffUtil.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumDiffUtil.kt
@@ -1,0 +1,14 @@
+package com.alfsuace.expmdmfebrero.presentation.adapter
+
+import androidx.recyclerview.widget.DiffUtil
+import com.alfsuace.expmdmfebrero.domain.Album
+
+class AlbumDiffUtil():DiffUtil.ItemCallback<Album>() {
+    override fun areItemsTheSame(oldItem: Album, newItem: Album): Boolean {
+        return oldItem.id==newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Album, newItem: Album): Boolean {
+        return oldItem==newItem
+    }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumViewHolder.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adapter/AlbumViewHolder.kt
@@ -1,0 +1,37 @@
+package com.alfsuace.expmdmfebrero.presentation.adapter
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.alfsuace.expmdmfebrero.R
+import com.alfsuace.expmdmfebrero.databinding.ViewAlbumItemBinding
+import com.alfsuace.expmdmfebrero.domain.Album
+
+class AlbumViewHolder(
+    itemView: View,
+    private val onClick: (Album) -> Unit,
+    private val onFavoriteClick: (Album) -> Unit
+) : RecyclerView.ViewHolder(itemView) {
+
+    private lateinit var binding: ViewAlbumItemBinding
+
+    fun bind(album: Album) {
+        binding = ViewAlbumItemBinding.bind(itemView)
+        binding.apply {
+            name.text = album.name
+            description.text = album.description
+
+            updateFavoriteIcon(album.favorite)
+
+            root.setOnClickListener { onClick(album) }
+            bookmark.setOnClickListener {
+                onFavoriteClick(album)
+            }
+        }
+    }
+
+    private fun updateFavoriteIcon(isFavorite: Boolean) {
+        val iconRes = if (isFavorite) R.drawable.ic_bookmark_filled else R.drawable.ic_bookmark_empty
+        binding.bookmark.setImageResource(iconRes)
+    }
+}
+

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomAdapter.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomAdapter.kt
@@ -1,0 +1,20 @@
+package com.alfsuace.expmdmfebrero.presentation.adaptersticker
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import com.alfsuace.expmdmfebrero.R
+import com.alfsuace.expmdmfebrero.domain.Mushroom
+
+class MushroomAdapter():ListAdapter<Mushroom, MushroomViewHolder>(MushroomDiffUtil()){
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MushroomViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.view_sticker_item, parent, false)
+        return MushroomViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: MushroomViewHolder, position: Int) {
+        val mushroom = getItem(position)
+        holder.bind(mushroom)
+    }
+
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomDiffUtil.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomDiffUtil.kt
@@ -2,7 +2,9 @@ package com.alfsuace.expmdmfebrero.presentation.adaptersticker
 
 import androidx.recyclerview.widget.DiffUtil
 import com.alfsuace.expmdmfebrero.domain.Mushroom
+import org.koin.core.annotation.Single
 
+@Single
 class MushroomDiffUtil:DiffUtil.ItemCallback<Mushroom>() {
     override fun areItemsTheSame(oldItem: Mushroom, newItem: Mushroom): Boolean {
         return oldItem.id==newItem.id

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomDiffUtil.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomDiffUtil.kt
@@ -1,0 +1,14 @@
+package com.alfsuace.expmdmfebrero.presentation.adaptersticker
+
+import androidx.recyclerview.widget.DiffUtil
+import com.alfsuace.expmdmfebrero.domain.Mushroom
+
+class MushroomDiffUtil:DiffUtil.ItemCallback<Mushroom>() {
+    override fun areItemsTheSame(oldItem: Mushroom, newItem: Mushroom): Boolean {
+        return oldItem.id==newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Mushroom, newItem: Mushroom): Boolean {
+        return oldItem==newItem
+    }
+}

--- a/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomViewHolder.kt
+++ b/app/src/main/java/com/alfsuace/expmdmfebrero/presentation/adaptersticker/MushroomViewHolder.kt
@@ -1,0 +1,20 @@
+package com.alfsuace.expmdmfebrero.presentation.adaptersticker
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.alfsuace.expmdmfebrero.databinding.ViewStickerItemBinding
+import com.alfsuace.expmdmfebrero.domain.Mushroom
+
+class MushroomViewHolder (itemView: View) : RecyclerView.ViewHolder(itemView) {
+
+    private lateinit var binding: ViewStickerItemBinding
+
+    fun bind(mushroom: Mushroom){
+        binding= ViewStickerItemBinding.bind(itemView)
+        binding.apply {
+            name.text=mushroom.name
+            description.text=mushroom.image
+        }
+    }
+
+}

--- a/app/src/main/res/drawable/ic_back.xml
+++ b/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_bookmark_empty.xml
+++ b/app/src/main/res/drawable/ic_bookmark_empty.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17,3L7,3c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3L19,5c0,-1.1 -0.9,-2 -2,-2zM17,18l-5,-2.18L7,18L7,5h10v13z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_bookmark_filled.xml
+++ b/app/src/main/res/drawable/ic_bookmark_filled.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17,3H7c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3V5c0,-1.1 -0.9,-2 -2,-2z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,19 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main"
+    android:id="@+id/nav_host_fragment"
+    android:name="androidx.navigation.fragment.NavHostFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    app:defaultNavHost="true"
+    app:navGraph="@navigation/nav_graph" />

--- a/app/src/main/res/layout/fragment_album_list.xml
+++ b/app/src/main/res/layout/fragment_album_list.xml
@@ -6,14 +6,14 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <include
-        android:id="@+id/toolbar"
+        android:id="@+id/toolbar_album"
         layout="@layout/main_toolbar"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/album_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_album"
         app:layout_constraintStart_toStartOf="parent"
         tools:listitem="@layout/view_album_item"/>
 

--- a/app/src/main/res/layout/fragment_album_list.xml
+++ b/app/src/main/res/layout/fragment_album_list.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/main_toolbar"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/album_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:listitem="@layout/view_album_item"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_detail_album.xml
+++ b/app/src/main/res/layout/fragment_detail_album.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/main_toolbar"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/sticker_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:listitem="@layout/view_sticker_item"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_detail_album.xml
+++ b/app/src/main/res/layout/fragment_detail_album.xml
@@ -7,7 +7,7 @@
     android:orientation="vertical">
 
     <include
-        android:id="@+id/toolbar"
+        android:id="@+id/toolbar_detail"
         layout="@layout/main_toolbar"/>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/main_toolbar.xml
+++ b/app/src/main/res/layout/main_toolbar.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:paddingTop="25dp"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:title="@string/toolbar_title"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        android:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:navigationIcon="@drawable/ic_back"
+        app:menu="@menu/toolbar_menu"
+        />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_album_item.xml
+++ b/app/src/main/res/layout/view_album_item.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/name"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toStartOf="parent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            tools:text="soy el nombre"
+            />
+        <TextView
+            android:id="@+id/description"
+            app:layout_constraintTop_toBottomOf="@id/name"
+            app:layout_constraintEnd_toStartOf="parent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="soy la descripcion"/>
+
+        <ImageView
+            android:id="@+id/bookmark"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_bookmark_empty"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:padding="8dp"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/view_sticker_item.xml
+++ b/app/src/main/res/layout/view_sticker_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 

--- a/app/src/main/res/layout/view_sticker_item.xml
+++ b/app/src/main/res/layout/view_sticker_item.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="nombre de la seta"
+        />
+    <TextView
+        android:id="@+id/description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="descripcion de la seta"/>
+
+</LinearLayout>

--- a/app/src/main/res/menu/toolbar_menu.xml
+++ b/app/src/main/res/menu/toolbar_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_bookmark"
+        android:icon="@drawable/ic_bookmark_empty"
+        android:title="Bookmark"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph">
+
+</navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/nav_graph">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/albumListFragment">
+
+    <fragment
+        android:id="@+id/albumListFragment"
+        android:name="com.alfsuace.expmdmfebrero.presentation.AlbumListFragment"
+        android:label="AlbumListFragment"
+        tools:layout="@layout/fragment_album_list"
+        >
+        <action
+            android:id="@+id/action_albumListFragment_to_stickerListFragment"
+            app:destination="@id/stickerListFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/stickerListFragment"
+        android:name="com.alfsuace.expmdmfebrero.presentation.StickerListFragment"
+        android:label="StickerListFragment" >
+        <argument
+            android:name="id"
+            app:argType="string" />
+    </fragment>
+
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">exPMDMFebrero</string>
+    <string name="toolbar_title">album de setas</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
-
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.safe.args) apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+
+    alias(libs.plugins.safe.args) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ material = "1.12.0"
 activity = "1.10.0"
 constraintlayout = "2.2.0"
 
+navigationFragmentKtx = "2.8.7"
+safearg="2.8.7"
+kotlinPlugin="2.0.21"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -20,7 +23,13 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 
+androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
+androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationFragmentKtx" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+safe-args={id="androidx.navigation.safeargs.kotlin", version.ref="safearg"}
+
+
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,12 @@ constraintlayout = "2.2.0"
 
 navigationFragmentKtx = "2.8.7"
 safearg="2.8.7"
-kotlinPlugin="2.0.21"
+koinBom="4.0.0"
+koinAnnotations = "1.4.0"
+ksp="2.0.21-1.0.26"
+viewmodelScope="2.8.7"
+gson = "2.12.1"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -23,6 +28,15 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 
+viewmodelscope={module="androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref="viewmodelScope"}
+
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+
+koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koinBom" }
+koin-android = { module = "io.insert-koin:koin-android" }
+koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koinAnnotations" }
+koin-ksp={module="io.insert-koin:koin-ksp-compiler", version.ref="koinAnnotations"}
+
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationFragmentKtx" }
 
@@ -30,6 +44,8 @@ androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx",
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 safe-args={id="androidx.navigation.safeargs.kotlin", version.ref="safearg"}
+ksp={id="com.google.devtools.ksp", version.ref="ksp"}
+
 
 
 


### PR DESCRIPTION
El problema nos pide que creemos una vista para una lista de albumes, los cuales se pueden marcar como favoritos y ver la lista de solo favoritos. Al clickar en un album podamos ver los datos dentro.

El problema le he resuelto creando dos recycler view, uno para el album y otro para el detalle, el cual tiene datos que tambien se repiten. Para pasar de una vista a otra se utiliza safe args, y tambien se implementa koin,
La vista maestra le pasa un id por safe args y un caso de uso se encarga de buscar el album

Mediante clean arquitecture se separa en capas:
-data: se implementa un sencillo sharedpreferences para guardar y recuperar del mock, estos datos van al data repository
-domain: se implementan los modelos un repositorio y dos casos de uso
-presentation: se implementan 2 recycler view, 2 fragments y 2 view model
-app: implementacion de Koin
-res: los layouts, navigation y el menu

Disclaimer:
Al volver del detalle se pierden los favoritos, porque no los guardo en el xml, esto queda fuera de pdmd

video de la funcionalidad

[funcionalidad funcionando.webm](https://github.com/user-attachments/assets/ece8fb8b-c070-43bd-8ff3-22314f3dd2c7)
